### PR TITLE
fix: only update movement on key up/down

### DIFF
--- a/client/src/scripts/utils/inputManager.ts
+++ b/client/src/scripts/utils/inputManager.ts
@@ -9,11 +9,20 @@ class Action {
     readonly name: string;
     readonly on?: () => void;
     readonly off?: () => void;
+    down: boolean = false;
 
     constructor(name: string, on?: () => void, off?: () => void) {
         this.name = name;
-        this.on = on;
-        this.off = off;
+        this.on = () => {
+            if (this.down) return;
+            this.down = true;
+            on?.();
+        };
+        this.off = () => {
+            if (!this.down) return;
+            this.down = false;
+            off?.();
+        }
     }
 }
 


### PR DESCRIPTION
## Description

When held down, keys would repeatedly fire "keydown" events and trigger extra updates. Added a variable into the Action class to prevent this.

## Type of change
* **fix**: A bug fix.

## How Has This Been Tested?

Minor client change, just tested locally.
