### PR TITLE
fix: tapping the minimap on mobile shows it for a second then hides it

### DIFF
--- a/client/src/scripts/scenes/minimapScene.ts
+++ b/client/src/scripts/scenes/minimapScene.ts
@@ -52,10 +52,16 @@ export class MinimapScene extends Phaser.Scene {
             else this.resizeSmallMap();
         });
 
-        // HACK: Use the gas rect to handle click events
-        this.gasRect.setInteractive().on("pointerdown", () => {
-            if (core.game?.playerManager.isMobile) this.toggle();
-        });
+        if (core.game?.playerManager.isMobile) {
+            const minimapElement = document.getElementById("minimap-border");
+            if (minimapElement) {
+                minimapElement.addEventListener("click", () => this.toggle());
+            }
+            // Using mousedown instead of pointerdown because we don't want to close the minimap if the user decides to move around while having it open
+            onmousedown = (e: MouseEvent): void => {
+                if (this.isExpanded) this.toggle();
+            };
+        }
 
         this.playerIndicator = this.add.image(0, 0, "main", "player_indicator.svg").setDepth(16).setScale(0.1 * MINIMAP_SCALE);
         this.switchToSmallMap();


### PR DESCRIPTION
# Suroi PR Submission Template

## Description

I fixed this using the minimap HTML element to listen to click events to open it, and a global click listener to close it.
Considered just using a time delta that checked if it was being closed too fast (Found out the "onpointerdown" event was being fired twice) but don't think it's a good idea.

## Type of change

Please delete options that are not relevant.

* **fix**: A bug fix.

## How Has This Been Tested?

- Opening and closing the minimap.
  -  Tested on Chrome mobile (114)
  -  Tested on Firefox mobile (117)
