### PR TITLE
Update guns.ts

### DIFF
--- a/common/src/definitions/guns.ts
+++ b/common/src/definitions/guns.ts
@@ -545,7 +545,7 @@ export const Guns: GunDefinition[] = [
         },
         image: { position: v(100, 0) },
         ballistics: {
-            damage: 300,
+            damage: 0.1, //temporary change to stop abuse (original 300)
             obstacleMultiplier: 2,
             speed: 0.5,
             maxDistance: 400,


### PR DESCRIPTION
Made the Death Ray useless because it was a dev-only advantage.



* **feat**: Changed the damage value of the death ray from 300 to 0.1

## How Has This Been Tested?

No testing necessary.
