### PR TITLE
Fix accidentally zooming in when playing on mobile

### DIFF
--- a/client/src/pages/index.html
+++ b/client/src/pages/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
     <meta name="title" content="Suroi - 2D battle royale game">
     <meta name="description"


### PR DESCRIPTION
## Description

I updated the meta viewport tag to disable zooming. This fixes the issue where on mobile devices you can accidentally zoom in when you click a button on the display (like the heals or guns) and you can only zoom out by dragging on any other buttons which is hard to do.
In the future the `user-scalable` value in the meta viewport tag’s content should probably be set using JavaScript so that it is `no` when the user is playing a game and `yes` otherwise.

## Type of change
* **feat**: A new feature.

## How Has This Been Tested?

I have run this on my own device and am unable to zoom in while playing the game.
