### PR TITLE
feat: death marker baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ server/bannedIPs.json
 # try to prevent chpster moments from happening
 *.desktop
 *.css
+/.vs/suroi-fresh/FileContentIndex
+/.vs/ProjectSettings.json
+/.vs/slnx.sqlite
+/.vs/suroi-fresh/v17/.wsuo
+/.vs/suroi-fresh/v17/workspaceFileList.bin
+/.vs/VSWorkspaceState.json

--- a/client/src/scripts/game.ts
+++ b/client/src/scripts/game.ts
@@ -47,6 +47,16 @@ import { DeathMarker } from "./objects/deathMarker";
 import { type LootDefinition } from "../../../common/src/definitions/loots";
 import { Scopes } from "../../../common/src/definitions/scopes";
 
+/*localStorageInstance.update({
+    "loadout": {
+        skin: "forest_camo",
+        deathMarker: "death_marker",
+        topEmote: "happy_face",
+        rightEmote: "thumbs_up",
+        bottomEmote: "suroi_logo",
+        leftEmote: "sad_face"
+    } })
+    */
 export class Game {
     socket!: WebSocket;
 

--- a/client/src/scripts/objects/deathMarker.ts
+++ b/client/src/scripts/objects/deathMarker.ts
@@ -26,7 +26,7 @@ export class DeathMarker extends GameObject {
     constructor(game: Game, type: ObjectType<ObjectCategory.DeathMarker>, id: number) {
         super(game, type, id);
 
-        this.image = new SuroiSprite("death_marker");
+        this.image = new SuroiSprite(localStorageInstance.config.loadout.deathMarker);
         this.playerNameText = new Text(localStorageInstance.config.anonymousPlayers ? DEFAULT_USERNAME : "",
             {
                 fontSize: 36,

--- a/client/src/scripts/utils/localStorageHandler.ts
+++ b/client/src/scripts/utils/localStorageHandler.ts
@@ -41,6 +41,7 @@ export interface Config {
         rightEmote: string
         bottomEmote: string
         leftEmote: string
+        deathMarker: string
     }
     scopeLooping: boolean
     anonymousPlayers: boolean
@@ -81,6 +82,7 @@ export const defaultConfig: Config = {
     rulesAcknowledged: false,
     loadout: {
         skin: "forest_camo",
+        deathMarker: "death_marker",
         topEmote: "happy_face",
         rightEmote: "thumbs_up",
         bottomEmote: "suroi_logo",


### PR DESCRIPTION
# Suroi PR Submission Template
Deathmarker base (custom death markers for players), need UI to change. 
## Description
Allows players to customise how they die with a custom death marker! (again.. need UI to change the death marker)

## Type of change
* **feat**: A new feature.

## How Has This Been Tested?
Ran locally in my system and works (but need more death marker svgs)

## Thing to do to make it work
So i commented out some code at top in `client/src/scripts/game.ts` where it updates your localstorage to add death marker property. uncomment that, run it with that, and then comment it back again. (this is how it worked for me)