### PR TITLE
Add a Nix shell environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+with (import <nixpkgs> { });
+mkShell {
+  buildInputs = [
+    nodejs
+    nodePackages.pnpm
+    libuuid
+    cairo
+    pango
+  ];
+  APPEND_LIBRARY_PATH = "${lib.makeLibraryPath [ libuuid ]}";
+  shellHook = ''
+    export LD_LIBRARY_PATH="$APPEND_LIBRARY_PATH:$LD_LIBRARY_PATH"
+  '';
+}


### PR DESCRIPTION
# Suroi PR Submission Template

## Description

This shell.nix file is for people who use Nix has their development environment. If this file isn't used, `dev:client` and `build:client` cannot be ran in NixOS.

## How Has This Been Tested?

`nix-shell`
