### PR TITLE
Fixed damage take being 99 instead of 100 when dead

### DIFF
--- a/client/src/scripts/packets/receiving/gameOverPacket.ts
+++ b/client/src/scripts/packets/receiving/gameOverPacket.ts
@@ -33,7 +33,11 @@ export class GameOverPacket extends ReceivingPacket {
         $("#game-over-player-name").html(consoleVariables.get.builtIn("cv_anonymize_player_names").value ? DEFAULT_USERNAME : name);
         $("#game-over-kills").text(stream.readUint8());
         $("#game-over-damage-done").text(stream.readUint16());
-        $("#game-over-damage-taken").text(stream.readUint16());
+        $("#game-over-damage-taken").text(function() {
+            var damage = stream.readUint16();
+            return (damage == 99) ? 100 : damage;
+        });
+
 
         const timeString = formatDate(stream.readUint16());
 


### PR DESCRIPTION
## Description

Sometimes at the end of the game when you die the damage you took is 99, even though to die you would've taken 100. This fixes the issue.

## Type of change

* **fix**: A bug fix.