### PR TITLE
Added rounded corners to description box in settings

### DIFF
--- a/client/src/scss/pages/dialog.scss
+++ b/client/src/scss/pages/dialog.scss
@@ -420,7 +420,8 @@
         #tab-keybinds-content {
             #keybind-clear-tooltip {
                 border: 2px solid gray;
-                padding: 3px;
+                border-radius: 10px;
+                padding: 7px;
                 background-color: lighten($transparent_bg, 30%);
             }
 


### PR DESCRIPTION
<img width="452" alt="Screenshot 2023-11-05 at 1 11 53 PM" src="https://github.com/HasangerGames/suroi/assets/66282302/cf1a9450-dfb2-4b87-bfaa-bf6438480195">
<img width="452" alt="Screenshot 2023-11-05 at 1 11 56 PM" src="https://github.com/HasangerGames/suroi/assets/66282302/27f7a39f-45a8-4ac8-a1ba-9e94d86004a4">

Padding/border changes too ig