### PR TITLE
fix: m1895 casings & other enhancements

### DIFF
--- a/common/src/definitions/guns.ts
+++ b/common/src/definitions/guns.ts
@@ -42,6 +42,18 @@ export type GunDefinition = ItemDefinition & {
         readonly count?: number
         readonly spawnOnReload?: boolean
         readonly ejectionDelay?: number
+        readonly velocity?: {
+            readonly x?: {
+                readonly min: number
+                readonly max: number
+                readonly randomSign?: boolean
+            }
+            readonly y?: {
+                readonly min: number
+                readonly max: number
+                readonly randomSign?: boolean
+            }
+        }
     }
 
     readonly image: {
@@ -316,7 +328,14 @@ const GunsRaw: Array<GunDefinition & {
         image: { position: v(95, 0) },
         casingParticles: {
             position: v(4.5, 0.6),
-            ejectionDelay: 450
+            ejectionDelay: 450,
+            velocity: {
+                y: {
+                    min: 2,
+                    max: 5,
+                    randomSign: true
+                }
+            }
         },
         singleReload: true,
         ballistics: {
@@ -398,7 +417,14 @@ const GunsRaw: Array<GunDefinition & {
         casingParticles: {
             position: v(4, 0.6),
             count: 2,
-            spawnOnReload: true
+            spawnOnReload: true,
+            velocity: {
+                y: {
+                    min: 8,
+                    max: 15,
+                    randomSign: true
+                }
+            }
         },
         ballistics: {
             damage: 10,
@@ -517,7 +543,7 @@ const GunsRaw: Array<GunDefinition & {
         },
         image: { position: v(90, 4) },
         casingParticles: {
-            position: v(4, 0.6),
+            position: v(2, 0.6),
             ejectionDelay: 700
         },
         ballistics: {
@@ -557,7 +583,18 @@ const GunsRaw: Array<GunDefinition & {
         casingParticles: {
             position: v(3.5, 0.5),
             count: 7,
-            spawnOnReload: true
+            spawnOnReload: true,
+            velocity: {
+                x: {
+                    min: -15,
+                    max: -4
+                },
+                y: {
+                    min: 5,
+                    max: 18,
+                    randomSign: true
+                }
+            }
         },
         capacity: 7,
         reloadTime: 2.1,
@@ -600,7 +637,13 @@ const GunsRaw: Array<GunDefinition & {
         },
         image: { position: v(65, 0) },
         casingParticles: {
-            position: v(3.5, 0.5)
+            position: v(3.5, 0.5),
+            velocity: {
+                y: {
+                    min: 2,
+                    max: 18
+                }
+            }
         },
         capacity: 15,
         reloadTime: 1.5,
@@ -686,7 +729,13 @@ const GunsRaw: Array<GunDefinition & {
         },
         image: { position: v(70, -1) },
         casingParticles: {
-            position: v(3.5, 0.5)
+            position: v(3.5, 0.5),
+            velocity: {
+                y: {
+                    min: 2,
+                    max: 18
+                }
+            }
         },
         capacity: 16,
         reloadTime: 1.9,
@@ -987,7 +1036,13 @@ const GunsRaw: Array<GunDefinition & {
         },
         image: { position: v(87, 1) },
         casingParticles: {
-            position: v(4, 0.6)
+            position: v(4, 0.6),
+            velocity: {
+                y: {
+                    min: 4,
+                    max: 15
+                }
+            }
         },
         ballistics: {
             damage: 39,
@@ -1101,7 +1156,13 @@ const GunsRaw: Array<GunDefinition & {
         },
         image: { position: v(85, 0) },
         casingParticles: {
-            position: v(5, 0.5)
+            position: v(5, 0.5),
+            velocity: {
+                y: {
+                    min: 4,
+                    max: 15
+                }
+            }
         },
         ballistics: {
             damage: 25.5,
@@ -1277,7 +1338,14 @@ const GunsRaw: Array<GunDefinition & {
         image: { position: v(80, 0) },
         casingParticles: {
             position: v(4, 0.6),
-            ejectionDelay: 450
+            ejectionDelay: 450,
+            velocity: {
+                y: {
+                    min: 2,
+                    max: 5,
+                    randomSign: true
+                }
+            }
         },
         singleReload: true,
         ballistics: {
@@ -1343,6 +1411,8 @@ export const Guns: GunDefinition[] = GunsRaw.map(e => {
     delete dualDef.image;
     // @ts-expect-error init code
     delete dualDef.casingParticles;
+    // @ts-expect-error init code
+    delete e.dual;
     // @ts-expect-error init code
     e.dualVariant = dualDef.idString;
 

--- a/common/src/definitions/modes.ts
+++ b/common/src/definitions/modes.ts
@@ -7,7 +7,7 @@ export interface ModeDefinition {
     readonly colors: Record<ColorKeys, string>
     readonly specialMenuMusic?: boolean
     readonly reskin?: string
-    // will be multiplied to the bullet trail color
+    // will be multiplied by the bullet trail color
     readonly bulletTrailAdjust?: string
 }
 

--- a/tests/src/validateDefinitions.ts
+++ b/tests/src/validateDefinitions.ts
@@ -23,6 +23,7 @@ import { LootTables, LootTiers } from "../../server/src/data/lootTables";
 import { Maps } from "../../server/src/data/maps";
 import { ColorStyles, FontStyles, styleText } from "../../common/src/utils/ansiColoring";
 import { logger, tester, validators } from "./validationUtils";
+import { Modes } from "../../common/src/definitions/modes";
 
 /*
     eslint-disable
@@ -1314,14 +1315,14 @@ logger.indent("Validating guns", () => {
                             obj: casings,
                             field: "count",
                             defaultValue: 1,
-                            baseErrorPath: errorPath
+                            baseErrorPath: errorPath2
                         });
 
                         if (casings.count !== undefined) {
                             tester.assertIsPositiveFiniteReal({
                                 obj: casings,
                                 field: "count",
-                                baseErrorPath: errorPath
+                                baseErrorPath: errorPath2
                             });
                         }
 
@@ -1329,21 +1330,105 @@ logger.indent("Validating guns", () => {
                             obj: casings,
                             field: "spawnOnReload",
                             defaultValue: false,
-                            baseErrorPath: errorPath
+                            baseErrorPath: errorPath2
                         });
 
                         tester.assertNoPointlessValue({
                             obj: casings,
                             field: "ejectionDelay",
                             defaultValue: 0,
-                            baseErrorPath: errorPath
+                            baseErrorPath: errorPath2
                         });
 
                         if (casings.ejectionDelay !== undefined) {
                             tester.assertIsPositiveFiniteReal({
                                 obj: casings,
                                 field: "ejectionDelay",
-                                baseErrorPath: errorPath
+                                baseErrorPath: errorPath2
+                            });
+                        }
+
+                        tester.assertNoPointlessValue({
+                            obj: casings,
+                            field: "velocity",
+                            defaultValue: {},
+                            equalityFunction: a => Object.keys(a).length === 0,
+                            baseErrorPath: errorPath2
+                        });
+
+                        if (casings.velocity) {
+                            logger.indent("Validating casing velocities", () => {
+                                const velocity = casings.velocity!;
+
+                                tester.assertNoPointlessValue({
+                                    obj: velocity,
+                                    field: "x",
+                                    defaultValue: {},
+                                    equalityFunction: a => Object.keys(a).length === 0,
+                                    baseErrorPath: errorPath2
+                                });
+
+                                if (velocity.x) {
+                                    tester.assertInBounds({
+                                        obj: velocity.x,
+                                        field: "min",
+                                        min: -Infinity,
+                                        max: velocity.x.max,
+                                        includeMin: false,
+                                        baseErrorPath: errorPath2
+                                    });
+
+                                    tester.assertInBounds({
+                                        obj: velocity.x,
+                                        field: "max",
+                                        min: velocity.x.min,
+                                        max: Infinity,
+                                        includeMax: false,
+                                        baseErrorPath: errorPath2
+                                    });
+
+                                    tester.assertNoPointlessValue({
+                                        obj: velocity.x,
+                                        field: "randomSign",
+                                        defaultValue: false,
+                                        baseErrorPath: errorPath2
+                                    });
+                                }
+
+                                tester.assertNoPointlessValue({
+                                    obj: velocity,
+                                    field: "y",
+                                    defaultValue: {},
+                                    equalityFunction: a => Object.keys(a).length === 0,
+                                    baseErrorPath: errorPath2
+                                });
+
+                                if (velocity.y) {
+                                    tester.assertInBounds({
+                                        obj: velocity.y,
+                                        field: "min",
+                                        min: -Infinity,
+                                        max: velocity.y.max,
+                                        includeMin: false,
+                                        baseErrorPath: errorPath2
+                                    });
+
+                                    tester.assertInBounds({
+                                        obj: velocity.y,
+                                        field: "max",
+                                        min: velocity.y.min,
+                                        max: Infinity,
+                                        includeMax: false,
+                                        baseErrorPath: errorPath2
+                                    });
+
+                                    tester.assertNoPointlessValue({
+                                        obj: velocity.y,
+                                        field: "randomSign",
+                                        defaultValue: false,
+                                        baseErrorPath: errorPath2
+                                    });
+                                }
                             });
                         }
                     });
@@ -1588,16 +1673,36 @@ logger.indent("Validating melees", () => {
     }
 });
 
-// TODO Validate modes
-/* logger.indent("Validating modes", () => {
+logger.indent("Validating modes", () => {
     tester.assertNoDuplicateIDStrings(Modes, "Modes", "modes");
 
     for (const mode of Modes) {
         logger.indent(`Validating mode '${mode.idString}'`, () => {
             const errorPath = tester.createPath("modes", `mode '${mode.idString}'`);
+
+            tester.assertNoPointlessValue({
+                obj: mode,
+                field: "specialMenuMusic",
+                defaultValue: false,
+                baseErrorPath: errorPath
+            });
+
+            tester.assertNoPointlessValue({
+                obj: mode,
+                field: "reskin",
+                defaultValue: "",
+                baseErrorPath: errorPath
+            });
+
+            tester.assertNoPointlessValue({
+                obj: mode,
+                field: "bulletTrailAdjust",
+                defaultValue: "",
+                baseErrorPath: errorPath
+            });
         });
     }
-}); */
+});
 
 logger.indent("Validating obstacles", () => {
     tester.assertNoDuplicateIDStrings(Obstacles.definitions, "Obstacles", "obstacles");


### PR DESCRIPTION
* **fix**: the dual m1895 casings now eject less stupidly
* **enhancement**: the casing ejection for some guns (m37, flues, m1895, etc) have been adjusted to better mimic reality (ignore the fact that the m1895's reload is completely wrong)
* **fix**: extremely important `delete` statement that prevents the world from sublimating