### PR TITLE
Bug Fix: Keyboard inputs not working if the user's language is not English.

### DIFF
--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -353,11 +353,11 @@ export class InputManager {
         if (event instanceof KeyboardEvent) {
             // This statement cross references and updates focus checks for key presses.
             if (down) {
-                if (!this.focusController.includes(event.key)) {
-                    this.focusController.push(event.key);
+                if (!this.focusController.includes(event.code.replace('Key', ''))) {
+                    this.focusController.push(event.code.replace('Key', ''));
                 }
             } else {
-                this.focusController = this.focusController.filter(item => item !== event.key);
+                this.focusController = this.focusController.filter(item => item !== event.code.replace('Key', ''));
             }
 
             let modifierCount = 0;
@@ -372,7 +372,7 @@ export class InputManager {
             if (
                 (
                     modifierCount > 1 ||
-                    (modifierCount === 1 && !["Control", "Meta"].includes(event.key))
+                    (modifierCount === 1 && !["Control", "Meta"].includes(event.code.replace('Key', '')))
                 ) && down
                 // …but it only invalidates pressing a key, not releasing it
             ) return;
@@ -432,7 +432,7 @@ export class InputManager {
     private getKeyFromInputEvent(event: KeyboardEvent | MouseEvent | WheelEvent): string {
         let key = "";
         if (event instanceof KeyboardEvent) {
-            key = event.key.length > 1 ? event.key : event.key.toUpperCase();
+            key = event.code.replace('Key', '').length > 1 ? event.code.replace('Key', '') : event.code.replace('Key', '').toUpperCase();
             if (key === " ") {
                 key = "Space";
             }


### PR DESCRIPTION
So basically event.key won't be the same if the user's language is "English". For example, "Z" key. In english, event.key value will be "Z", which is correct. However, in other lanugages it will be different. My method might not be such good but it is a fix. Basically event.code is a constant value of the keypress. "Z" will always be "KeyZ" value, so just remove the "Key" from the string and user's language won't affect keypresses anymore. I submitted a bug report on this I think on April 2nd. This breaks numbers though..