### PR TITLE
Fix on the getKeyFromInputEvent function. (inputManager.ts)

### DIFF
--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -442,7 +442,7 @@ export class InputManager {
             switch (true) {
                 // If it's a letter, use it's code and not it's value.
                 case keyPressed.startsWith('Key'):
-                    keyPressed = keyPressed.substring(3);
+                    keyPressed = keyPressed.replace("Key", "");
                     break;
 
                 // Special Condition: Semicolon's value seems to be glitchy.

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -432,10 +432,38 @@ export class InputManager {
     private getKeyFromInputEvent(event: KeyboardEvent | MouseEvent | WheelEvent): string {
         let key = "";
         if (event instanceof KeyboardEvent) {
-            key = event.key.length > 1 ? event.key : event.key.toUpperCase();
+
+            // ---------------------------------------------------------------------------------------
+            // BUG FIX: key.event not being constant (for letters), resulting in key inputs not being
+            // read properly if the player's keyboard language is not set to ENG (English)
+            // ---------------------------------------------------------------------------------------
+            let keyPressed = event.code;
+
+            // If it's a letter, use it's code and not it's value.
+            if (keyPressed.includes('Key')) {
+
+                // Make sure it's only the key character.
+                keyPressed = event.code.replace('Key', '');
+            }
+
+            // Otherwise, use the key's value since it's not affected by keyboard language.
+            else {
+                keyPressed = event.key;
+
+                // -----------------------------------------------------------------------
+                // Special Condition: Semicolon's value seems to be glitchy.
+                // -----------------------------------------------------------------------
+                if (keyPressed === 'Dead' && event.code === 'Semicolon') keyPressed = ';';
+                // -----------------------------------------------------------------------
+            }
+
+            key = keyPressed.length > 1 ? keyPressed : keyPressed.toUpperCase();
+
             if (key === " ") {
                 key = "Space";
             }
+            // ---------------------------------------------------------------------------------------
+
         }
 
         if (event instanceof WheelEvent) {

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -432,38 +432,10 @@ export class InputManager {
     private getKeyFromInputEvent(event: KeyboardEvent | MouseEvent | WheelEvent): string {
         let key = "";
         if (event instanceof KeyboardEvent) {
-
-            // ---------------------------------------------------------------------------------------
-            // BUG FIX: key.event not being constant (for letters), resulting in key inputs not being
-            // read properly if the player's keyboard language is not set to ENG (English)
-            // ---------------------------------------------------------------------------------------
-            let keyPressed = event.code;
-
-            // If it's a letter, use it's code and not it's value.
-            if (keyPressed.includes('Key')) {
-
-                // Make sure it's only the key character.
-                keyPressed = event.code.replace('Key', '');
-            }
-
-            // Otherwise, use the key's value since it's not affected by keyboard language.
-            else {
-                keyPressed = event.key;
-
-                // -----------------------------------------------------------------------
-                // Special Condition: Semicolon's value seems to be glitchy.
-                // -----------------------------------------------------------------------
-                if (keyPressed === 'Dead' && event.code === 'Semicolon') keyPressed = ';';
-                // -----------------------------------------------------------------------
-            }
-
-            key = keyPressed.length > 1 ? keyPressed : keyPressed.toUpperCase();
-
+            key = event.key.length > 1 ? event.key : event.key.toUpperCase();
             if (key === " ") {
                 key = "Space";
             }
-            // ---------------------------------------------------------------------------------------
-
         }
 
         if (event instanceof WheelEvent) {

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -439,22 +439,20 @@ export class InputManager {
             // ---------------------------------------------------------------------------------------
             let keyPressed = event.code;
 
-            // If it's a letter, use it's code and not it's value.
-            if (keyPressed.includes('Key')) {
+            switch (true) {
+                // If it's a letter, use it's code and not it's value.
+                case keyPressed.startsWith('Key'):
+                    keyPressed = keyPressed.substring(3);
+                    break;
 
-                // Make sure it's only the key character.
-                keyPressed = event.code.replace('Key', '');
-            }
-
-            // Otherwise, use the key's value since it's not affected by keyboard language.
-            else {
-                keyPressed = event.key;
-
-                // -----------------------------------------------------------------------
                 // Special Condition: Semicolon's value seems to be glitchy.
-                // -----------------------------------------------------------------------
-                if (keyPressed === 'Dead' && event.code === 'Semicolon') keyPressed = ';';
-                // -----------------------------------------------------------------------
+                case keyPressed === 'Dead' && event.code === 'Semicolon':
+                    keyPressed = ';';
+                    break;
+                // Otherwise, use the key's value since it's not affected by keyboard language.
+                default:
+                    keyPressed = event.key;
+                    break;
             }
 
             key = keyPressed.length > 1 ? keyPressed : keyPressed.toUpperCase();


### PR DESCRIPTION
Hello again, here's the updated version of my bug fix without the use of the depreciated `event.keyCode`. This time I used `event.code` as one of you told me to look into (I think it was ei-pi).

Anyways, my goal is to fix the bug where the keyboard events are not read correctly due to `event.key` not having a constant value in different keyboard languages (for example, `Greek/ΕΛ` ). My fix basically uses the `event.code` by removing the `"Key"` from the string so we can have a correct reading on the key that was pressed (for example, `"R"`, which is for reload by default).

For your information, I created the bug fix by hosting the game locally in my computer and tested it as well.

By the way, the semicolon seemed to have an issue so I added a special case for it because the value it was returning with event.key was `"Dead"`. 

Ignore the `Update inputManager` commit (because it's the code without the bug fix that I reverted for a test), I encountered an issue and could not commit the new version with the bug fix and it wouldn't let me PR.