### PR TITLE
Fix on the "Scope inside buildings" bug (inventory.ts)

### DIFF
--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -432,10 +432,38 @@ export class InputManager {
     private getKeyFromInputEvent(event: KeyboardEvent | MouseEvent | WheelEvent): string {
         let key = "";
         if (event instanceof KeyboardEvent) {
-            key = event.key.length > 1 ? event.key : event.key.toUpperCase();
+
+            // ---------------------------------------------------------------------------------------
+            // BUG FIX: key.event not being constant (for letters), resulting in key inputs not being
+            // read properly if the player's keyboard language is not set to ENG (English)
+            // ---------------------------------------------------------------------------------------
+            let keyPressed = event.code;
+
+            // If it's a letter, use it's code and not it's value.
+            if (keyPressed.includes('Key')) {
+
+                // Make sure it's only the key character.
+                keyPressed = event.code.replace('Key', '');
+            }
+
+            // Otherwise, use the key's value since it's not affected by keyboard language.
+            else {
+                keyPressed = event.key;
+
+                // -----------------------------------------------------------------------
+                // Special Condition: Semicolon's value seems to be glitchy.
+                // -----------------------------------------------------------------------
+                if (keyPressed === 'Dead' && event.code === 'Semicolon') keyPressed = ';';
+                // -----------------------------------------------------------------------
+            }
+
+            key = keyPressed.length > 1 ? keyPressed : keyPressed.toUpperCase();
+
             if (key === " ") {
                 key = "Space";
             }
+            // ---------------------------------------------------------------------------------------
+
         }
 
         if (event instanceof WheelEvent) {

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -432,38 +432,10 @@ export class InputManager {
     private getKeyFromInputEvent(event: KeyboardEvent | MouseEvent | WheelEvent): string {
         let key = "";
         if (event instanceof KeyboardEvent) {
-
-            // ---------------------------------------------------------------------------------------
-            // BUG FIX: key.event not being constant (for letters), resulting in key inputs not being
-            // read properly if the player's keyboard language is not set to ENG (English)
-            // ---------------------------------------------------------------------------------------
-            let keyPressed = event.code;
-
-            // If it's a letter, use it's code and not it's value.
-            if (keyPressed.includes('Key')) {
-
-                // Make sure it's only the key character.
-                keyPressed = event.code.replace('Key', '');
-            }
-
-            // Otherwise, use the key's value since it's not affected by keyboard language.
-            else {
-                keyPressed = event.key;
-
-                // -----------------------------------------------------------------------
-                // Special Condition: Semicolon's value seems to be glitchy.
-                // -----------------------------------------------------------------------
-                if (keyPressed === 'Dead' && event.code === 'Semicolon') keyPressed = ';';
-                // -----------------------------------------------------------------------
-            }
-
-            key = keyPressed.length > 1 ? keyPressed : keyPressed.toUpperCase();
-
+            key = event.key.length > 1 ? event.key : event.key.toUpperCase();
             if (key === " ") {
                 key = "Space";
             }
-            // ---------------------------------------------------------------------------------------
-
         }
 
         if (event instanceof WheelEvent) {

--- a/server/src/inventory/inventory.ts
+++ b/server/src/inventory/inventory.ts
@@ -485,7 +485,14 @@ export class Inventory {
                 for (let i = Scopes.definitions.length - 1; i >= 0; i--) {
                     const scope = Scopes.definitions[i];
                     if (this.items.hasItem(scope.idString)) {
-                        this.scope = this.owner.effectiveScope = scope;
+
+                        // --------------------------------------------------------------------------------------------
+                        // BUG FIX: The scope "hack" in buildings. We do not need to set "effectiveScope" if the
+                        // player is inside a bulding, because it's already set to the 1x by the building in player.ts
+                        // --------------------------------------------------------------------------------------------
+                        this.scope = this.owner.isInsideBuilding ? scope : this.owner.effectiveScope = scope;
+                        // --------------------------------------------------------------------------------------------
+
                         break;
                     }
                 }


### PR DESCRIPTION
Small bug fix so that when you drop a scope inside a building you no longer have it's zoom level but the 1x zoom level as it should be.

The issue was quite simple. In `player.ts`, the effectiveScope is set to 1x (`DEFAULT_SCOPE`) when the player is inside a building, however, in `inventory.ts`, the `effectiveScope` is set again but there is no check about being inside building. So yeah.

***ignore the inputManager.ts commits, I forgot to revert the master branch before working on another bug fix***