### PR TITLE
Update melees.ts (baseball bat can pierce)

### DIFF
--- a/client/changelog/index.html
+++ b/client/changelog/index.html
@@ -57,7 +57,6 @@ v0.17.1 - [4/20/2024]
 - Fixed loot and death markers animating when they shouldn't
 - Fixed reviving not being canceled when the player being revived despawns
 - Fixed knocked out players not dying if their teammate despawns
-- Fixed slight clipping of skins in the menu
 - Fixed ping counter always displaying, even if disabled
 - Fixed misaligned rules close button
 

--- a/common/src/definitions/melees.ts
+++ b/common/src/definitions/melees.ts
@@ -65,6 +65,7 @@ export const Melees = ObjectDefinitions.create<MeleeDefinition>()(
             name: "Baseball Bat",
             damage: 34,
             obstacleMultiplier: 1.5,
+            piercingMultiplier: 1,
             radius: 3.8,
             offset: Vec.create(3.8, 2.2),
             cooldown: 340,


### PR DESCRIPTION
In surviv.io the wood axe could break ammo crates along with some other melee weapons, the only way to break the ammo crates in suroi is with the maul. I think the baseball bat should be buffed to be able to break crates, so that they have some more unility  (at least as a placeholder until we have more piercing meeles)