### PR TITLE
Fix: Unnecessary image fetches

### DIFF
--- a/client/src/scripts/managers/uiManager.ts
+++ b/client/src/scripts/managers/uiManager.ts
@@ -1265,7 +1265,9 @@ class PlayerHealthUI {
 
         if (recalcIndicatorFrame) {
             const frame = `player_indicator${this._normalizedHealth.value === 0 ? "_dead" : this._downed.value ? "_downed" : ""}`;
-            this.teammateIndicator.attr("src", `./img/game/player/${frame}.svg`);
+            if (this.teammateIndicator.attr("src") !== `./img/game/player/${frame}.svg`) {
+                this.teammateIndicator.attr("src", `./img/game/player/${frame}.svg`);
+            }
             indicator?.setFrame(frame);
         }
 
@@ -1303,12 +1305,10 @@ class PlayerHealthUI {
 
             if (teammate) {
                 if (teammate.badge) {
-                    this.badgeImage
-                        .attr(
-                            "src",
-                            `./img/game/badges/${teammate.badge.idString}.svg`
-                        )
-                        .css({ display: "", visibility: "" });
+                    if (this.badgeImage.attr("src") !== `./img/game/badges/${teammate.badge.idString}.svg`) {
+                        this.badgeImage.attr("src", `./img/game/badges/${teammate.badge.idString}.svg`);
+                    }
+                    this.badgeImage.css({ display: "", visibility: "" });
                 } else {
                     this.badgeImage
                         .attr("src", "")

--- a/client/src/scripts/managers/uiManager.ts
+++ b/client/src/scripts/managers/uiManager.ts
@@ -1265,8 +1265,9 @@ class PlayerHealthUI {
 
         if (recalcIndicatorFrame) {
             const frame = `player_indicator${this._normalizedHealth.value === 0 ? "_dead" : this._downed.value ? "_downed" : ""}`;
-            if (this.teammateIndicator.attr("src") !== `./img/game/player/${frame}.svg`) {
-                this.teammateIndicator.attr("src", `./img/game/player/${frame}.svg`);
+            const newSrc = `./img/game/player/${frame}.svg`;
+            if (this.teammateIndicator.attr("src") !== newSrc) {
+                this.teammateIndicator.attr("src", newSrc);
             }
             indicator?.setFrame(frame);
         }
@@ -1305,8 +1306,9 @@ class PlayerHealthUI {
 
             if (teammate) {
                 if (teammate.badge) {
-                    if (this.badgeImage.attr("src") !== `./img/game/badges/${teammate.badge.idString}.svg`) {
-                        this.badgeImage.attr("src", `./img/game/badges/${teammate.badge.idString}.svg`);
+                    const newSrc = `./img/game/badges/${teammate.badge.idString}.svg`;
+                    if (this.badgeImage.attr("src") !== newSrc) {
+                        this.badgeImage.attr("src", newSrc);
                     }
                     this.badgeImage.css({ display: "", visibility: "" });
                 } else {


### PR DESCRIPTION
Every tick the `teammateIndicator` and `badgeImage` images are updated with the same source as before, creating unnecessary http requests.