### PR TITLE
Adren regen rate change

### DIFF
--- a/client/src/scripts/rendering/camera.ts
+++ b/client/src/scripts/rendering/camera.ts
@@ -60,7 +60,7 @@ export class Camera {
                 {
                     target: this.container.scale,
                     to: { x: scale, y: scale },
-                    duration: 1900,
+                    duration: 800,
                     ease: EaseFunctions.cubicOut,
                     onComplete: () => {
                         this.zoomTween = undefined;

--- a/client/src/scripts/rendering/camera.ts
+++ b/client/src/scripts/rendering/camera.ts
@@ -60,7 +60,7 @@ export class Camera {
                 {
                     target: this.container.scale,
                     to: { x: scale, y: scale },
-                    duration: 800,
+                    duration: 1900,
                     ease: EaseFunctions.cubicOut,
                     onComplete: () => {
                         this.zoomTween = undefined;

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -701,10 +701,10 @@ export class Player extends BaseGameObject<ObjectCategory.Player> {
         }
 
         // Regenerate health
-        if (this._adrenaline >= 87.5) this.health += dt * 2.75 / (30 ** 2);
-        else if (this._adrenaline >= 50) this.health += dt * 2.125 / (30 ** 2);
-        else if (this._adrenaline >= 25) this.health += dt * 1.125 / (30 ** 2);
-        else if (this._adrenaline > 0) this.health += dt * 0.625 / (30 ** 2);
+        if (this._adrenaline >= 87.5) this.health += dt * 5 / (50 ** 2);
+        else if (this._adrenaline >= 50) this.health += dt * 4.75 / (50 ** 2);
+        else if (this._adrenaline >= 25) this.health += dt * 3.75 / (50 ** 2);
+        else if (this._adrenaline > 0) this.health += dt * 1 / (50 ** 2);
 
         // Shoot gun/use item
         if (this.startedAttacking) {

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -701,10 +701,10 @@ export class Player extends BaseGameObject<ObjectCategory.Player> {
         }
 
         // Regenerate health
-        if (this._adrenaline >= 87.5) this.health += dt * 5 / (50 ** 2);
-        else if (this._adrenaline >= 50) this.health += dt * 4.75 / (50 ** 2);
-        else if (this._adrenaline >= 25) this.health += dt * 3.75 / (50 ** 2);
-        else if (this._adrenaline > 0) this.health += dt * 1 / (50 ** 2);
+        if (this._adrenaline >= 87.5) this.health += dt * 4.35 / (50 ** 2);
+        else if (this._adrenaline >= 50) this.health += dt * 3.75 / (50 ** 2);
+        else if (this._adrenaline >= 25) this.health += dt * 3.125 / (50 ** 2);
+        else if (this._adrenaline > 0) this.health += dt * 2.5 / (50 ** 2);
 
         // Shoot gun/use item
         if (this.startedAttacking) {


### PR DESCRIPTION
Adrenaline heals too fast. A player can just run around a long obstacle for a few seconds and heal tons of hp, this also makes snipers horrible against level 3 armor with decent adrenaline, cause the damage done is almost completely healed back in a few seconds.

![Suroi-2Dbattleroyalegameand2morepages-Personal-MicrosoftEdge2024-06-2413-03-08-ezgif com-video-to-gif-converter](https://github.com/HasangerGames/suroi/assets/107775211/db60a295-1b31-4a7d-893b-873163d752eb)
