### PR TITLE
fix: set the 12.7mm capacity of the level 1 backpack to 20

### DIFF
--- a/common/src/definitions/backpacks.ts
+++ b/common/src/definitions/backpacks.ts
@@ -60,7 +60,7 @@ export const Backpacks = ObjectDefinitions.create<BackpackDefinition>()(
                     "556mm": 180,
                     "762mm": 180,
                     "9mm": 240,
-                    "127mm": 10,
+                    "127mm": 20,
                     "power_cell": Infinity,
                     "curadell": 2,
                     "firework_rocket": 20,


### PR DESCRIPTION
previously it was 10, which was also the capacity of the level 0 backpack