### PR TITLE
feat: hide scrollbar in loading screen

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -62,6 +62,7 @@
     <style>
       body {
         background-color: #49993e;
+        overflow: hidden;
       }
       body > :not(.loading-logo) {
         opacity: 0;


### PR DESCRIPTION
In the very beginning loading screen, where the only element is the suroi icon rotating, there is a scrollbar on the right because of the overflow. Yes, I tested these changes