### PR TITLE
Setting to allow switching joystick functions

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -953,6 +953,13 @@
           </div>
           <div class="modal-item checkbox-setting">
             <label>
+              <span class="setting-title"><span>Switch mobile joysticks</span><i></i></span>
+              <input type="checkbox" id="toggle-mobile-joysticks">
+            </label>
+          </div>
+          <p style="color: red; font-size: 15px" id="mb-joystick-info"><i>Left joystick moves, Right joystick aims</i></p>
+          <div class="modal-item checkbox-setting">
+            <label>
               <span class="setting-title" translation="settings_autopickup"></span>
               <input type="checkbox" id="toggle-auto-pickup">
             </label>

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -273,28 +273,35 @@ export class InputManager {
             const size = game.console.getBuiltInCVar("mb_joystick_size");
             const transparency = game.console.getBuiltInCVar("mb_joystick_transparency");
 
-            const leftJoyStick = nipplejs.create({
+            const leftJoystick = nipplejs.create({
                 zone: $("#left-joystick-container")[0],
                 size,
                 color: `rgba(255, 255, 255, ${transparency})`
             });
 
-            const rightJoyStick = nipplejs.create({
+            const rightJoystick = nipplejs.create({
                 zone: $("#right-joystick-container")[0],
                 size,
                 color: `rgba(255, 255, 255, ${transparency})`
             });
-
-            let rightJoyStickUsed = false;
+            let movementJoystick = leftJoystick;
+            let aimJoystick = rightJoystick;
+            const mbJoystickInfo = document.getElementById("mb-joystick-info");
+            if (game.console.getBuiltInCVar("mb_switch_joysticks")) {
+                movementJoystick = rightJoystick;
+                aimJoystick = leftJoystick;
+                if (mbJoystickInfo) mbJoystickInfo.textContent = "Right joystick moves, Left joystick aims";
+            } else if (mbJoystickInfo) mbJoystickInfo.textContent = "Left joystick moves, Right joystick aims";
+            let aimJoystickUsed = false;
             let shootOnRelease = false;
 
-            leftJoyStick.on("move", (_, data: JoystickOutputData) => {
+            movementJoystick.on("move", (_, data: JoystickOutputData) => {
                 const movementAngle = -Math.atan2(data.vector.y, data.vector.x);
 
                 this.movementAngle = movementAngle;
                 this.movement.moving = true;
 
-                if (!rightJoyStickUsed && !shootOnRelease) {
+                if (!aimJoystickUsed && !shootOnRelease) {
                     this.rotation = movementAngle;
                     this.turning = true;
                     if (game.console.getBuiltInCVar("cv_responsive_rotation") && !game.gameOver && game.activePlayer) {
@@ -303,12 +310,12 @@ export class InputManager {
                 }
             });
 
-            leftJoyStick.on("end", () => {
+            movementJoystick.on("end", () => {
                 this.movement.moving = false;
             });
 
-            rightJoyStick.on("move", (_, data) => {
-                rightJoyStickUsed = true;
+            aimJoystick.on("move", (_, data) => {
+                aimJoystickUsed = true;
                 this.rotation = -Math.atan2(data.vector.y, data.vector.x);
                 this.turning = true;
                 const activePlayer = game.activePlayer;
@@ -334,8 +341,8 @@ export class InputManager {
                 }
             });
 
-            rightJoyStick.on("end", () => {
-                rightJoyStickUsed = false;
+            aimJoystick.on("end", () => {
+                aimJoystickUsed = false;
                 if (game.activePlayer) game.activePlayer.images.aimTrail.alpha = 0;
                 this.attacking = shootOnRelease;
                 this.resetAttacking = true;

--- a/client/src/scripts/ui.ts
+++ b/client/src/scripts/ui.ts
@@ -1600,6 +1600,7 @@ export async function setUpUI(game: Game): Promise<void> {
     addCheckboxListener("#toggle-mobile-controls", "mb_controls_enabled");
     addSliderListener("#slider-joystick-size", "mb_joystick_size");
     addSliderListener("#slider-joystick-transparency", "mb_joystick_transparency");
+    addCheckboxListener("#toggle-mobile-joysticks", "mb_switch_joysticks");
     addCheckboxListener("#toggle-high-res-mobile", "mb_high_res_textures");
 
     function updateUiScale(): void {

--- a/client/src/scripts/utils/console/defaultClientCVars.ts
+++ b/client/src/scripts/utils/console/defaultClientCVars.ts
@@ -90,6 +90,7 @@ export const CVarCasters = Object.freeze({
     mb_controls_enabled: Casters.toBoolean,
     mb_joystick_size: Casters.toNumber,
     mb_joystick_transparency: Casters.toNumber,
+    mb_switch_joysticks: Casters.toBoolean,
     mb_high_res_textures: Casters.toBoolean,
 
     dv_password: Casters.toString,
@@ -214,6 +215,7 @@ export const defaultClientCVars: SimpleCVarMapping = Object.freeze({
     pf_show_ping: false,
     pf_show_pos: false,
 
+    mb_switch_joysticks: false,
     mb_controls_enabled: true,
     mb_joystick_size: 150,
     mb_joystick_transparency: 0.8,


### PR DESCRIPTION
If enabled, your right joystick will become your movement joystick, and your left will become your aiming joystick, pretty straight forward.
As with all mobile settings however, this requires a reload to apply.