### PR TITLE
Ability to change colors of mobile joysticks

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -951,7 +951,19 @@
               <input type="range" max="1" min="0.1" id="slider-joystick-transparency" step="0.1">
             </label>
           </div>
-          <div class="modal-item checkbox-setting">
+          <div class="modal-item">
+            <label>
+              <span class="setting-title">Left joystick color:</span>
+              <input type="color" style="margin-right: 135px" id="left-joystick-color-picker">
+            </label>
+          </div>
+      <div style="margin-top: 25px" class="modal-item">
+            <label>
+              <span class="setting-title">Right joystick color:</span>
+              <input type="color" style="margin-right: 135px" id="right-joystick-color-picker">
+            </label>
+          </div>
+          <div class="modal-item checkbox-setting" style="margin-top: 25px">
             <label>
               <span class="setting-title" translation="settings_autopickup"></span>
               <input type="checkbox" id="toggle-auto-pickup">

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -272,17 +272,21 @@ export class InputManager {
         if (this.isMobile) {
             const size = game.console.getBuiltInCVar("mb_joystick_size");
             const transparency = game.console.getBuiltInCVar("mb_joystick_transparency");
+            function joystickColor(transparency: number, input: string): string {
+                const hexAlpha = Math.round(transparency * 255).toString(16).padStart(2, "0");
+                return input + hexAlpha;
+            }
 
             const leftJoyStick = nipplejs.create({
                 zone: $("#left-joystick-container")[0],
                 size,
-                color: `rgba(255, 255, 255, ${transparency})`
+                color: joystickColor(transparency, game.console.getBuiltInCVar("mb_left_joystick_color"))
             });
 
             const rightJoyStick = nipplejs.create({
                 zone: $("#right-joystick-container")[0],
                 size,
-                color: `rgba(255, 255, 255, ${transparency})`
+                color: joystickColor(transparency, game.console.getBuiltInCVar("mb_right_joystick_color"))
             });
 
             let rightJoyStickUsed = false;

--- a/client/src/scripts/ui.ts
+++ b/client/src/scripts/ui.ts
@@ -1600,6 +1600,14 @@ export async function setUpUI(game: Game): Promise<void> {
     addCheckboxListener("#toggle-mobile-controls", "mb_controls_enabled");
     addSliderListener("#slider-joystick-size", "mb_joystick_size");
     addSliderListener("#slider-joystick-transparency", "mb_joystick_transparency");
+    (document.getElementById("left-joystick-color-picker") as HTMLInputElement).value = game.console.getBuiltInCVar("mb_left_joystick_color");
+    (document.getElementById("right-joystick-color-picker") as HTMLInputElement).value = game.console.getBuiltInCVar("mb_right_joystick_color");
+    $<HTMLInputElement>("#left-joystick-color-picker").on("input", function() {
+        game.console.setBuiltInCVar("mb_left_joystick_color", this.value);
+    });
+    $<HTMLInputElement>("#right-joystick-color-picker").on("input", function() {
+        game.console.setBuiltInCVar("mb_right_joystick_color", this.value);
+    });
     addCheckboxListener("#toggle-high-res-mobile", "mb_high_res_textures");
 
     function updateUiScale(): void {

--- a/client/src/scripts/utils/console/defaultClientCVars.ts
+++ b/client/src/scripts/utils/console/defaultClientCVars.ts
@@ -90,6 +90,8 @@ export const CVarCasters = Object.freeze({
     mb_controls_enabled: Casters.toBoolean,
     mb_joystick_size: Casters.toNumber,
     mb_joystick_transparency: Casters.toNumber,
+    mb_left_joystick_color: Casters.toString,
+    mb_right_joystick_color: Casters.toString,
     mb_high_res_textures: Casters.toBoolean,
 
     dv_password: Casters.toString,
@@ -217,6 +219,8 @@ export const defaultClientCVars: SimpleCVarMapping = Object.freeze({
     mb_controls_enabled: true,
     mb_joystick_size: 150,
     mb_joystick_transparency: 0.8,
+    mb_left_joystick_color: "#FFFFFF",
+    mb_right_joystick_color: "#FFFFFF",
     mb_high_res_textures: false,
 
     dv_password: "",


### PR DESCRIPTION
Note: this uses hex instead of RGBA, but I did account for the transparency slider