### PR TITLE
You also get a scope from gold rock

### DIFF
--- a/server/src/data/lootTables.ts
+++ b/server/src/data/lootTables.ts
@@ -264,7 +264,8 @@ export const LootTables: Record<string, Record<string, LootTable>> = {
             [{ table: "scopes", weight: 1 }]
         ],
         gold_rock: [
-            { item: "mosin_nagant", weight: 1 }
+            { item: "mosin_nagant", weight: 1 },
+            [{ table: "scopes", weight: 1 }]
         ],
         loot_tree: [
             [


### PR DESCRIPTION
Since the Mosin-Nagant spawns without a scope, can we add a scope to it because snipers are not good with scopes