### PR TITLE
Change Mk-18 Mjölnir reload time from 3.8 to 2.6

### DIFF
--- a/common/src/definitions/guns.ts
+++ b/common/src/definitions/guns.ts
@@ -2060,7 +2060,7 @@ export const Guns = ObjectDefinitions.withDefault<GunDefinition>()(
                 gasParticles: gasParticlePresets.rifle,
                 capacity: 5,
                 extendedCapacity: 10,
-                reloadTime: 3.8,
+                reloadTime: 2.6,
                 ballistics: {
                     damage: 90,
                     obstacleMultiplier: 1.5,


### PR DESCRIPTION
It takes too long for the Mk-18 Mjölnir to reload. If you are in the middle of a fight, you have to wait 4 seconds for it to reload.