### PR TITLE
enhance: load UI elements before fetchServerData

### DIFF
--- a/client/src/scripts/game.ts
+++ b/client/src/scripts/game.ts
@@ -54,7 +54,7 @@ import { ThrowableProjectile } from "./objects/throwableProj";
 import { Camera } from "./rendering/camera";
 import { Gas, GasRender } from "./rendering/gas";
 import { Minimap } from "./rendering/minimap";
-import { autoPickup, fetchServerData, reloadPage, resetPlayButtons, setUpUI, teamSocket, unlockPlayButtons, updateDisconnectTime } from "./ui";
+import { autoPickup, fetchServerData, reloadPage, resetPlayButtons, setUpUI, finalizeUI, teamSocket, unlockPlayButtons, updateDisconnectTime } from "./ui";
 import { setUpCommands } from "./utils/console/commands";
 import { defaultClientCVars } from "./utils/console/defaultClientCVars";
 import { GameConsole } from "./utils/console/gameConsole";
@@ -218,6 +218,7 @@ export class Game {
         game.console.readFromLocalStorage();
         setUpCommands(game);
         await initTranslation(game);
+        await setUpUI(game);
         await fetchServerData(game);
         game.inputManager.generateBindsConfigScreen();
         game.inputManager.setupInputs();
@@ -318,7 +319,7 @@ export class Game {
         void Promise.all([
             initPixi(),
             game.soundManager.loadSounds(game),
-            setUpUI(game)
+            finalizeUI(game)
         ]).then(() => {
             unlockPlayButtons();
             resetPlayButtons(game);

--- a/client/src/scripts/ui.ts
+++ b/client/src/scripts/ui.ts
@@ -262,10 +262,8 @@ export async function fetchServerData(game: Game): Promise<void> {
     });
 }
 
-export async function setUpUI(game: Game): Promise<void> {
-    const { inputManager, uiManager } = game;
-    const { ui } = uiManager;
-
+// Take the stuff that needs fetchServerData out of setUpUI and put it here
+export async function finalizeUI(game: Game): Promise<void> {
     // Change the menu based on the mode.
     $("#splash-ui").css("background-image", `url(./img/backgrounds/menu/${game.modeName}.png)`);
     if (game.mode.specialLogo) $("#splash-logo").children("img").attr("src", `./img/logos/suroi_beta_${game.modeName}.svg`);
@@ -287,6 +285,20 @@ export async function setUpUI(game: Game): Promise<void> {
             }
         }
     }
+
+    // Darken canvas (halloween mode)
+    if (game.mode.darkShaders) {
+        $("#game-canvas").css({
+            "filter": "brightness(0.65) saturate(0.85)",
+            "position": "relative",
+            "z-index": "-1"
+        });
+    }
+}
+
+export async function setUpUI(game: Game): Promise<void> {
+    const { inputManager, uiManager } = game;
+    const { ui } = uiManager;
 
     if (UI_DEBUG_MODE) {
         ui.inventoryMsg.show();
@@ -1222,15 +1234,6 @@ export async function setUpUI(game: Game): Promise<void> {
     const crosshairControls = $<HTMLDivElement>("#crosshair-controls");
     const crosshairTargets = $<HTMLDivElement>("#crosshair-preview, #game");
 
-    // Darken canvas (halloween mode)
-    if (game.mode.darkShaders) {
-        $("#game-canvas").css({
-            "filter": "brightness(0.65) saturate(0.85)",
-            "position": "relative",
-            "z-index": "-1"
-        });
-    }
-
     // Load crosshairs
     function loadCrosshair(): void {
         const size = 20 * game.console.getBuiltInCVar("cv_crosshair_size");
@@ -1429,7 +1432,7 @@ export async function setUpUI(game: Game): Promise<void> {
         });
 
         const value = game.console.getBuiltInCVar(settingName) as number;
-        callback?.(value);
+        // callback?.(value); why is this here?
         element.value = value.toString();
     }
 


### PR DESCRIPTION
As per todo: https://discord.com/channels/1077043833621184563/1341458926230700126

The slider callback registration called the callback immediately, which did not serve much function (commented it out). This was a block that required server data to be fetched before loading the UI. The stuff that did need the server data, such as the player counts and special rendering for certain modes have been put in finalizeUI, which is called where setUpUI used to be called.