### PR TITLE
Fixed explosion weapon wont swap when killed

### DIFF
--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -2195,8 +2195,13 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
                 packet.creditedId = downedBy.id;
                 if (downedBy !== this) packet.kills = ++downedBy.kills;
             }
-            if (this.game.mode.weaponSwap && downedBy !== undefined){
-                if (!(weaponUsed instanceof Explosion)) downedBy.swapWeaponRandomly(weaponUsed, true);
+
+            if (this.game.mode.weaponSwap && downedBy !== undefined) {
+                if (!(weaponUsed instanceof Explosion)) {
+                    downedBy.swapWeaponRandomly(weaponUsed, true);
+                } else if (weaponUsed.weapon) {
+                    downedBy.swapWeaponRandomly(weaponUsed.weapon, true);
+                }
             }
         } else if (source instanceof Player && source !== this) {
             this.killedBy = source;

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -2183,7 +2183,6 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
         }
 
         const downedBy = this.downedBy?.player;
-        //downed by someone and got killed by gas
         if (
             source === DamageSources.Gas
             || source === DamageSources.Airdrop
@@ -2255,13 +2254,16 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
                     }
                 }
             }
-            if (this.game.mode.weaponSwap && !(weaponUsed instanceof Explosion)) {
-                source.swapWeaponRandomly(weaponUsed, true);
 
-            //swap gun if killed by explosive guns/breaking barrel with gun
-            } else if (weaponUsed instanceof Explosion) {
-                if (weaponUsed.weapon) source.swapWeaponRandomly(weaponUsed.weapon, true);
+            // Weapon swap
+            if (this.game.mode.weaponSwap) {
+                if (!(weaponUsed instanceof Explosion)) {
+                    source.swapWeaponRandomly(weaponUsed, true);
+                } else if (weaponUsed.weapon) {
+                    source.swapWeaponRandomly(weaponUsed.weapon, true);
+                }
             }
+            
             source.updateAndApplyModifiers();
         }
 

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -2197,8 +2197,7 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
                 if (downedBy !== this) packet.kills = ++downedBy.kills;
             }
             if (this.game.mode.weaponSwap && downedBy !== undefined){
-                if (!(weaponUsed instanceof Explosion))
-                downedBy.swapWeaponRandomly(weaponUsed, true);
+                if (!(weaponUsed instanceof Explosion)) downedBy.swapWeaponRandomly(weaponUsed, true);
             }
         } else if (source instanceof Player && source !== this) {
             this.killedBy = source;
@@ -2258,9 +2257,9 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
             }
             if (this.game.mode.weaponSwap && !(weaponUsed instanceof Explosion)) {
                 source.swapWeaponRandomly(weaponUsed, true);
-            }
-//swap gun if killed by explosive guns/breaking barrel with gun
-            if (weaponUsed instanceof Explosion){
+
+            //swap gun if killed by explosive guns/breaking barrel with gun
+            } else if (weaponUsed instanceof Explosion) {
                 if (weaponUsed.weapon) source.swapWeaponRandomly(weaponUsed.weapon, true);
             }
             source.updateAndApplyModifiers();

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -2183,6 +2183,7 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
         }
 
         const downedBy = this.downedBy?.player;
+        //downed by someone and got killed by gas
         if (
             source === DamageSources.Gas
             || source === DamageSources.Airdrop
@@ -2194,6 +2195,10 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
             if (downedBy !== undefined) {
                 packet.creditedId = downedBy.id;
                 if (downedBy !== this) packet.kills = ++downedBy.kills;
+            }
+            if (this.game.mode.weaponSwap && downedBy !== undefined){
+                if (!(weaponUsed instanceof Explosion))
+                downedBy.swapWeaponRandomly(weaponUsed, true);
             }
         } else if (source instanceof Player && source !== this) {
             this.killedBy = source;
@@ -2251,11 +2256,13 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
                     }
                 }
             }
-
             if (this.game.mode.weaponSwap && !(weaponUsed instanceof Explosion)) {
                 source.swapWeaponRandomly(weaponUsed, true);
             }
-
+//swap gun if killed by explosive guns/breaking barrel with gun
+            if (weaponUsed instanceof Explosion){
+                if (weaponUsed.weapon) source.swapWeaponRandomly(weaponUsed.weapon, true);
+            }
             source.updateAndApplyModifiers();
         }
 


### PR DESCRIPTION
more exactly:
this patched the issue that USAS wont swap when killed a player
also when player is downed and got killed by environment, the one who knocked him out will get a random swap on the weapon he used to knock him down