### PR TITLE
feat: make map generation determined by seed

### DIFF
--- a/common/src/utils/random.ts
+++ b/common/src/utils/random.ts
@@ -105,7 +105,7 @@ export class SeededRandom {
 
     /**
      * @param [min = 0] min value (included)
-     * @param [max = 1] max value (excluded)
+     * @param [max = 1] max value (included)
      */
     getInt(min = 0, max = 1): number {
         return Math.round(this.get(min, max));

--- a/common/src/utils/random.ts
+++ b/common/src/utils/random.ts
@@ -1,4 +1,6 @@
+import { RectangleHitbox } from "./hitbox";
 import { Numeric } from "./math";
+import { ObjectDefinition, ReferenceOrNull, ReferenceOrRandom } from "./objectDefinitions";
 import { type Vector } from "./vector";
 
 /**
@@ -110,4 +112,54 @@ export class SeededRandom {
     getInt(min = 0, max = 1): number {
         return Math.round(this.get(min, max));
     }
+}
+
+export function seededRandomRotation(seededRandom: SeededRandom): number {
+    // use radians so -pi to pi
+    return seededRandom.get(-Math.PI, Math.PI);
+}
+
+export function seededPickRandomInArray<T>(items: readonly T[], seededRandom: SeededRandom): T {
+    return items[Math.floor(seededRandom.get(0, items.length))];
+}
+
+export function seededRandomFloat(min: number, max: number, seededRandom: SeededRandom): number {
+    return seededRandom.get(min, max);
+}
+
+export function seededRandomBoolean(seededRandom: SeededRandom): boolean {
+    return seededRandom.get() < 0.5;
+}
+
+export function seededGetRandomIDString<T extends ObjectDefinition>(ref: ReferenceOrRandom<T>, seededRandom: SeededRandom): ReferenceOrNull<T> {
+    if (typeof ref === "string") return ref;
+
+    const items: Array<ReferenceOrNull<T>> = [];
+    const weights: number[] = [];
+    for (const [item, weight] of Object.entries(ref) as ReadonlyArray<readonly [ReferenceOrNull<T>, number]>) {
+        items.push(item);
+        weights.push(weight);
+    }
+    return seededWeightedRandom(items, weights, seededRandom);
+}
+
+export function seededWeightedRandom<T>(items: readonly T[], weights: readonly number[], seededRandom: SeededRandom): T {
+    let pick = seededRandom.get() * weights.reduce((acc, cur) => acc + cur, 0);
+    let i = 0;
+    while ((pick -= weights[i++]) > 0);
+    return items[--i];
+}
+
+export function seededRandomVector(minX: number, maxX: number, minY: number, maxY: number, randomGenerator: SeededRandom): Vector {
+    return {
+        x: randomGenerator.get(minX, maxX),
+        y: randomGenerator.get(minY, maxY)
+    };
+}
+
+export function seededRectangleRandomPoint(rect: RectangleHitbox, randomGenerator: SeededRandom): Vector {
+    return {
+        x: seededRandomFloat(rect.min.x, rect.max.x, randomGenerator),
+        y: seededRandomFloat(rect.min.y, rect.max.y, randomGenerator)
+    };
 }


### PR DESCRIPTION
This PR makes the generation of obstacles' and buildings' positions and orientation the same given the same seed. This should be helpful for debugging and adding new features.


To change the seed, go to `server/src/map.ts` and change this line of code to whatever you want the seed to be.
```typescript
this.seed = packet.seed = random(0, 2 ** 31);
``` 

To spawn in the same place, go to `server/src/config.ts` and change
```typescript
spawn: { mode: SpawnMode.Default }
``` 
to 
```typescript
spawn: { mode: SpawnMode.Fixed, position: [x, y] }
``` 
where `x` is your _x coordinate_ and `y` is your _y coordinate_