### PR TITLE
make mp-153 extetended capacity to 12

### DIFF
--- a/common/src/definitions/items/guns.ts
+++ b/common/src/definitions/items/guns.ts
@@ -1825,6 +1825,7 @@ export const Guns = new InventoryItemDefinitions<GunDefinition>(([
         itemType: ItemType.Gun,
         ammoSpawnAmount: 16,
         capacity: 8,
+        extendedCapacity: 12,
         reloadTime: 0.45,
         shotsPerReload: 1,
         fireDelay: 400,


### PR DESCRIPTION
other shotguns(m3k, model 37, hp18) have extended capacity. can the mp153 also have extended capacity since it is similar to the ↑ guns?