### PR TITLE
Ammo color fixes

### DIFF
--- a/client/src/scripts/managers/mapManager.ts
+++ b/client/src/scripts/managers/mapManager.ts
@@ -25,11 +25,11 @@ class MapManagerClass {
     set expanded(expand: boolean) {
         if (this._expanded === expand) return;
 
-        if (this._expanded = expand) this.switchToBigMap();
-        else this.switchToSmallMap();
+        if (this._expanded = expand){ this.switchToBigMap();}
+        else {this.switchToSmallMap(); this.toggleMinimap(); this.toggleMinimap(); }
     }
 
-    toggle(): void { this.expanded = !this._expanded; }
+    toggle(): void { this.expanded = !this._expanded;}
 
     private _visible = true;
     get visible(): boolean { return this._visible; }
@@ -41,7 +41,7 @@ class MapManagerClass {
         this._borderContainer.toggle(visible);
     }
 
-    toggleMinimap(): void { this.visible = !this._visible; }
+    toggleMinimap(): void {this.visible = !this._visible;}
 
     private _position = Vec(0, 0);
     private _lastPosition = Vec(0, 0);
@@ -747,6 +747,7 @@ class MapManagerClass {
     }
 
     switchToSmallMap(): void {
+
         this._expanded = false;
 
         const ui = UIManager.ui;

--- a/client/src/scripts/managers/mapManager.ts
+++ b/client/src/scripts/managers/mapManager.ts
@@ -21,12 +21,12 @@ import { UIManager } from "./uiManager";
 
 class MapManagerClass {
     private _expanded = false;
-    get expanded(): boolean { return this._expanded; }
+    get expanded(): boolean {return this._expanded; }
     set expanded(expand: boolean) {
         if (this._expanded === expand) return;
 
-        if (this._expanded = expand){ this.switchToBigMap();}
-        else {this.switchToSmallMap(); this.toggleMinimap(); this.toggleMinimap(); }
+        if (this._expanded = expand){this.switchToBigMap();}
+        else {this.switchToSmallMap(); this.toggleMinimap(); this.toggleMinimap();}
     }
 
     toggle(): void { this.expanded = !this._expanded;}
@@ -34,14 +34,19 @@ class MapManagerClass {
     private _visible = true;
     get visible(): boolean { return this._visible; }
     set visible(visible: boolean) {
+        if (this._expanded) {
+            return;
+        }
         this._visible = visible;
-
         this.switchToSmallMap();
+
         this.container.visible = visible;
         this._borderContainer.toggle(visible);
     }
 
     toggleMinimap(): void {this.visible = !this._visible;}
+
+
 
     private _position = Vec(0, 0);
     private _lastPosition = Vec(0, 0);
@@ -711,12 +716,15 @@ class MapManagerClass {
             this._objectsContainer.position.set(-this._width / 2, 0);
             return;
         }
-        const pos = Vec.clone(this._position);
-        pos.x -= (this._minimapWidth / 2 + this.margins.x) / this.container.scale.x;
-        pos.y -= (this._minimapHeight / 2 + this.margins.y) / this.container.scale.y;
+        else
+        {
+            const pos = Vec.clone(this._position);
+            pos.x -= (this._minimapWidth / 2 + this.margins.x) / this.container.scale.x;
+            pos.y -= (this._minimapHeight / 2 + this.margins.y) / this.container.scale.y;
 
-        this.container.position.set(0, 0);
-        this._objectsContainer.position.copyFrom(Vec.scale(pos, -1));
+            this.container.position.set(0, 0);
+            this._objectsContainer.position.copyFrom(Vec.scale(pos, -1));
+        }
     }
 
     private readonly _uiCache = Object.freeze({
@@ -729,7 +737,6 @@ class MapManagerClass {
 
     switchToBigMap(): void {
         this._expanded = true;
-
         const ui = UIManager.ui;
         this.container.visible = true;
         this._borderContainer.hide();
@@ -747,9 +754,7 @@ class MapManagerClass {
     }
 
     switchToSmallMap(): void {
-
         this._expanded = false;
-
         const ui = UIManager.ui;
 
         this._uiCache.closeMinimap.hide();
@@ -777,8 +782,8 @@ class MapManagerClass {
 
         this._borderContainer.show();
         this.resize();
-    }
 
+    }
     updateTransparency(): void {
         this.container.alpha = GameConsole.getBuiltInCVar(
             this._expanded

--- a/client/src/scripts/managers/uiManager.ts
+++ b/client/src/scripts/managers/uiManager.ts
@@ -1036,7 +1036,6 @@ class UIManagerClass {
             let isAmmoFull = false;
         if (weapon?.definition?.defType === DefinitionType.Gun && ammo !== undefined) {
             const def = weapon.definition as GunDefinition;
-            // extendedCapacity is the TOTAL capacity with extended mag, not additional
         if (def.extendedCapacity == null){
             const maxAmmo = def.capacity;
              isAmmoFull = ammo >= maxAmmo;
@@ -1057,7 +1056,7 @@ class UIManagerClass {
             cache.isAmmoFull = isAmmoFull;
             cache.hasAmmo = hasAmmo;
             ammoCounter.css("color", ammoColor);
-        }    
+        }    //does this work?
     }
     }
 

--- a/client/src/scripts/managers/uiManager.ts
+++ b/client/src/scripts/managers/uiManager.ts
@@ -35,6 +35,7 @@ import { MapManager } from "./mapManager";
 import { ClientPerkManager } from "./perkManager";
 import { ScreenRecordManager } from "./screenRecordManager";
 import { SoundManager } from "./soundManager";
+import type { GunDefinition } from "@common/definitions/items/guns";
 
 function safeRound(value: number): number {
     if (0 < value && value <= 1) return 1;
@@ -932,7 +933,7 @@ class UIManagerClass {
         for (let i = 0, max = GameConstants.player.maxWeapons; i < max; i++) {
             const weapon = inventory.weapons[i];
             const isNew = this.weaponCache[i] === undefined;
-            const cache = this.weaponCache[i] ??= {};
+      const cache = (this.weaponCache[i] ??= {}) as any;
 
             const {
                 container,
@@ -1032,13 +1033,32 @@ class UIManagerClass {
                 cache.ammo = ammo;
                 ammoCounter.text(ammo ?? "");
             }
-
-            const hasAmmo = ammo !== undefined && ammo > 0;
-            if (hasAmmo !== cache.hasAmmo || isNew) {
-                cache.hasAmmo = hasAmmo;
-                ammoCounter.css("color", hasAmmo ? "unset" : "red");
-            }
+            let isAmmoFull = false;
+        if (weapon?.definition?.defType === DefinitionType.Gun && ammo !== undefined) {
+            const def = weapon.definition as GunDefinition;
+            // extendedCapacity is the TOTAL capacity with extended mag, not additional
+        if (def.extendedCapacity == null){
+            const maxAmmo = def.capacity;
+             isAmmoFull = ammo >= maxAmmo;
         }
+        else{
+              const maxAmmo = def.capacity;
+               isAmmoFull = ammo >= maxAmmo;
+        }
+        }
+            const hasAmmo = ammo !== undefined && ammo > 0;
+            const ammoColor = isAmmoFull
+                ? "orange"
+                : hasAmmo
+                    ? "unset"
+                    : "red";
+
+        if (isAmmoFull !== cache.isAmmoFull || hasAmmo !== cache.hasAmmo || isNew) {
+            cache.isAmmoFull = isAmmoFull;
+            cache.hasAmmo = hasAmmo;
+            ammoCounter.css("color", ammoColor);
+        }    
+    }
     }
 
     private _playSlotAnimation(element: JQuery): void {


### PR DESCRIPTION
I made the ammo left number turn orange when the gun is full. It does not work for extended magazines yet. It also does not work for the throwables. Also, ignore the mapManager file. I did not know how to remove it from this push request.