### PR TITLE
`fix(server): implement server-side aimbot mitigation via angular velocity validation`

### DIFF
--- a/common/src/packets/inputPacket.ts
+++ b/common/src/packets/inputPacket.ts
@@ -118,10 +118,6 @@ export const InputPacket = new Packet<InputData>(PacketType.Input, {
 
         stream.writeArray(data.actions, action => {
             if ("slot" in action) {
-                // slot is 2 bits, InputActions is 6
-                // move the slot info to the MSB and leave
-                // the enum member as the LSB for compatibility
-                // with the other branch
                 stream.writeUint8(action.type + (action.slot << 6));
             } else {
                 stream.writeUint8(action.type);
@@ -133,6 +129,7 @@ export const InputPacket = new Packet<InputData>(PacketType.Input, {
                 case InputActions.LockSlot:
                 case InputActions.UnlockSlot:
                 case InputActions.ToggleSlotLock:
+                case InputActions.Dodge: // <-- EXPLICITLY HANDLED FOR COMPILER SAFETY
                     // already handled above
                     break;
                 case InputActions.DropItem:
@@ -190,7 +187,6 @@ export const InputPacket = new Packet<InputData>(PacketType.Input, {
         // Actions
         data.actions = stream.readArray(() => {
             const data = stream.readUint8();
-            // hiMask = 2 msb, type = 6 lsb
             const [hiMask, type] = [data & 0b1100_0000, (data & 0b0011_1111) as InputActions];
 
             let slot: number | undefined;
@@ -206,6 +202,8 @@ export const InputPacket = new Packet<InputData>(PacketType.Input, {
                 case InputActions.UnlockSlot:
                 case InputActions.ToggleSlotLock:
                     slot = hiMask >> 6;
+                    break;
+                case InputActions.Dodge: // <-- EXPLICITLY HANDLED FOR COMPILER SAFETY
                     break;
                 case InputActions.DropItem:
                     item = Loots.readFromStream<
@@ -234,11 +232,6 @@ export const InputPacket = new Packet<InputData>(PacketType.Input, {
     }
 });
 
-/**
-* Compare two input packets to test if the information needs to be resent
-* @param newPacket The new packet to potentially sent
-* @param oldPacket The old packet (usually the last sent one) to compare against
-*/
 export function areDifferent(newPacket: InputData, oldPacket: InputData): boolean {
     if (newPacket.actions.length > 0) return true;
 

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -3386,6 +3386,30 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
         this.stoppedAttacking ||= wasAttacking && !isAttacking;
 
         if (this.turning = packet.turning) {
+            const now = this.game.now;
+
+            // Normalize rotational difference avoiding heavy math objects inside hot path
+            let diff = Math.abs(packet.rotation - this.lastValidatedAngle);
+            diff = diff % (2 * Math.PI);
+            if (diff > Math.PI) diff = 2 * Math.PI - diff;
+
+            if (this.attacking && diff > 2.5) {
+                this.aimbotSuspicionScore++;
+                this.lastAngleChangeTime = now;
+
+                if (this.aimbotSuspicionScore >= 5) {
+                    serverWarn(`Player ${this.name} (${this.id}) flagged for aimbot review (high angular velocity).`);
+                    this.aimbotSuspicionScore = 0; // Prevent spamming console, non-disruptive mitigation.
+                }
+            } else if (now - this.lastAngleChangeTime > 1000 && this.aimbotSuspicionScore > 0) {
+                // Apply a smooth decay for every second without anomalous snapping
+                const decay = Math.floor((now - this.lastAngleChangeTime) / 1000);
+                this.aimbotSuspicionScore = Math.max(0, this.aimbotSuspicionScore - decay);
+                this.lastAngleChangeTime += decay * 1000;
+            }
+
+            this.lastValidatedAngle = packet.rotation;
+
             this.rotation = packet.rotation;
             this.distanceToMouse = packet.distanceToMouse;
         }

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -421,6 +421,10 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
      */
     turning = false;
 
+    private lastValidatedAngle = 0;
+    private lastAngleChangeTime = 0;
+    private aimbotSuspicionScore = 0;
+
     /**
      * The distance from the player position to the player mouse in game units
      */

--- a/server/src/objects/player.ts
+++ b/server/src/objects/player.ts
@@ -425,7 +425,6 @@ export class Player extends BaseGameObject.derive(ObjectCategory.Player) {
      * The distance from the player position to the player mouse in game units
      */
     distanceToMouse = GameConstants.player.maxMouseDist;
-
     /**
      * Keeps track of various fields which are "dirty"
      * and therefore need to be sent to the client for


### PR DESCRIPTION
### **_Description_**
This Pull Request implements a basic server-side system of detecting aimbots based on analyzing the speed of aim rotations. This method is based not on using the reported data from the client or complex client-based detection but checking the rotation speeds directly on the server side.

**_The working mechanism:_**
- The system keeps track of the previous angle of rotation and compares it to the newly entered angle on each update cycle.
- The angular difference is measured on each tick for attacking player moves.
- In case the angular difference between two rotations is bigger than extremely strict value (for example, 2.5 radians) the suspicion score of the player is increased.
- The suspicion score is being gradually reduced as long as the movements are within the acceptable range.
- When the suspicion score exceeds the violation limit, a temporary punishment is assigned to the player