### PR TITLE
fixes the mobile joystick lockup bugs (#370 / #404).

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "colord": "^2.9.3",
         "fontfaceobserver": "^2.3.0",
         "jquery": "^3.7.1",
-        "nipplejs": "^0.10.2",
+        "nipplejs": "^1.0.4",
         "pixi-filters": "^6.1.5",
         "pixi.js": "^8.19.0",
         "spritesheetc": "^1.0.0-alpha5",
@@ -1092,7 +1092,7 @@
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
-    "nipplejs": ["nipplejs@0.10.2", "", {}, "sha512-XGxFY8C2DOtobf1fK+MXINTzkkXJLjZDDpfQhOUZf4TSytbc9s4bmA0lB9eKKM8iDivdr9NQkO7DpIQfsST+9g=="],
+    "nipplejs": ["nipplejs@1.0.4", "", {}, "sha512-YtvRZDuyWQ+tOj0nUjfnZt4ZQmJVWfK9+yPmV5OXpQ4k4AkOGcSfKvSXbPNkV0ERqc4eakkBSZ7/Wyx1y6h/Sg=="],
 
     "no-case": ["no-case@3.0.4", "", { "dependencies": { "lower-case": "^2.0.2", "tslib": "^2.0.3" } }, "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,7 @@
     "colord": "^2.9.3",
     "fontfaceobserver": "^2.3.0",
     "jquery": "^3.7.1",
-    "nipplejs": "^0.10.2",
+    "nipplejs": "^1.0.4",
     "pixi-filters": "^6.1.5",
     "pixi.js": "^8.19.0",
     "spritesheetc": "^1.0.0-alpha5"

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -350,18 +350,18 @@ class InputManagerClass {
         }
 
         window.addEventListener("blur", () => {
-    for (const k of this._focusController) {
-        this.handleLostFocus(k);
-    }
+            for (const k of this._focusController) {
+                this.handleLostFocus(k);
+            }
 
-    this._focusController.clear();
+            this._focusController.clear();
 
-    
-    if (this.isMobile) {
-        this.movement.moving = false;
-        this.attacking = false;
-    }
-});
+        
+            if (this.isMobile) {
+                this.movement.moving = false;
+                this.attacking = false;
+            }
+        });
 
         // different event targets… why?
         window.addEventListener("keydown", this.handleInputEvent.bind(this, true));

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -8,7 +8,7 @@ import { Geometry, Numeric } from "@common/utils/math";
 import { DefinitionType, type ItemDefinition } from "@common/utils/objectDefinitions";
 import { Vec } from "@common/utils/vector";
 import $ from "jquery";
-import nipplejs, { type JoystickOutputData } from "nipplejs";
+import nipplejs from "nipplejs";
 import { isMobile } from "pixi.js";
 import { GameConsole, type GameSettings, type PossibleError } from "../console/gameConsole";
 import { defaultBinds } from "../console/variables";
@@ -350,10 +350,13 @@ class InputManagerClass {
         }
 
         window.addEventListener("blur", () => {
-            for (const k of this._focusController) {
-                this.handleLostFocus(k);
+     
+            if (this.isMobile) {
+                this.movement.moving = false;
+                this.attacking = false;
             }
-
+            
+            this._focusController.forEach(key => this.handleLostFocus(key));
             this._focusController.clear();
         });
 
@@ -421,7 +424,7 @@ class InputManagerClass {
             let aimJoystickUsed = false;
             let shootOnRelease = false;
 
-            movementJoystick.on("move", (_, data: JoystickOutputData) => {
+            movementJoystick.on("move", ({ data }) => {
                 const angle = -data.angle.radian;
                 this.movementAngle = angle;
                 this.movement.moving = true;
@@ -439,7 +442,7 @@ class InputManagerClass {
                 this.movement.moving = false;
             });
 
-            aimJoystick.on("move", (_, data) => {
+            aimJoystick.on("move", ({ data }) => {
                 aimJoystickUsed = true;
                 this.rotation = -data.angle.radian;
                 this.turning = true;

--- a/client/src/scripts/managers/inputManager.ts
+++ b/client/src/scripts/managers/inputManager.ts
@@ -350,15 +350,18 @@ class InputManagerClass {
         }
 
         window.addEventListener("blur", () => {
-     
-            if (this.isMobile) {
-                this.movement.moving = false;
-                this.attacking = false;
-            }
-            
-            this._focusController.forEach(key => this.handleLostFocus(key));
-            this._focusController.clear();
-        });
+    for (const k of this._focusController) {
+        this.handleLostFocus(k);
+    }
+
+    this._focusController.clear();
+
+    
+    if (this.isMobile) {
+        this.movement.moving = false;
+        this.attacking = false;
+    }
+});
 
         // different event targets… why?
         window.addEventListener("keydown", this.handleInputEvent.bind(this, true));


### PR DESCRIPTION
Addresses the issue where mobile joysticks randomly get stuck on WebKit/iOS devices (#370, #404).

The older version of the library (0.10.2) has pointer-tracking bugs on WebKit where multitouch inputs are dropped during concurrent gestures or when a finger slides off the screen. Upgrading to 1.0.4 resolves this by tracking individual pointer IDs in an internal map.

I updated the two move handlers in inputManager.ts to use the new ({ data }) signature to match the updated v1.x API. 

I also added a clean state reset inside the window blur event listener for mobile. If a mobile player is interrupted by an OS-level event (like pulling down the notification shade or switching apps), both movement and attack inputs are cleared to prevent the player's state from freezing.

Tested locally on desktop with FORCE_MOBILE. I don't have an iOS device, so it may not work 